### PR TITLE
fix(login): preserve confirm password errors

### DIFF
--- a/src/app/pages/login/login.spec.ts
+++ b/src/app/pages/login/login.spec.ts
@@ -114,6 +114,18 @@ describe('Login Component', () => {
       expect(loginPasswordControl?.hasError('minlength')).toBeFalsy();
       expect(registerPasswordControl?.hasError('minlength')).toBeFalsy();
     });
+
+    it('should preserve other errors on confirmPassword when passwords mismatch', () => {
+      const passwordControl = component.registerForm.get('password');
+      const confirmControl = component.registerForm.get('confirmPassword');
+
+      passwordControl?.setValue('password123');
+      confirmControl?.setValue('123'); // triggers minlength
+      component.registerForm.updateValueAndValidity();
+
+      expect(confirmControl?.errors?.['minlength']).toBeTruthy();
+      expect(confirmControl?.errors?.['mismatch']).toBeTruthy();
+    });
   });
 
   describe('Login Functionality', () => {

--- a/src/app/pages/login/login.ts
+++ b/src/app/pages/login/login.ts
@@ -33,7 +33,9 @@ export function passwordsMatcher(
   const confirmPassword = control.get('confirmPassword');
 
   if (password && confirmPassword && password.value !== confirmPassword.value) {
-    confirmPassword.setErrors({ mismatch: true });
+    // Preserve existing errors while adding mismatch
+    const existingErrors = confirmPassword.errors || {};
+    confirmPassword.setErrors({ ...existingErrors, mismatch: true });
     return { mismatch: true };
   } else if (confirmPassword) {
     const errors = confirmPassword.errors;


### PR DESCRIPTION
## Summary
- retain existing confirmPassword validation errors when passwords mismatch
- cover confirmPassword error handling with new unit test

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a2b42ec960832aa5d179efc7dedba5